### PR TITLE
feat: Loop to check all labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 npx octoherd-script-copy-labels \
   --octoherd-token 0123456789012345678901234567890123456789 \
   "bdougie/*" \
-  --template bdougie/live
+  --template bdougie/live \
+  -- octoherd-bypass-confirms true // To bypass each label confirmation.
 ```
-
 ## Options
 
 | option       | type   | description                                                           |

--- a/script.js
+++ b/script.js
@@ -8,4 +8,51 @@
  * @param {object} options
  * @param {string} options.template this is the repo you want the labels to be copied from
  */
-export async function script(octokit, repository, { template }) {}
+export async function script(octokit, repository, { template }) {
+  if (!template) {
+    throw new Error(`--template is required`);
+  }
+
+  octokit.log.debug(
+    "Load branch protection settings from template repository %s",
+    template
+  );
+
+  const [templateOwner, templateRepo] = template.split("/");
+  const [repoOwner, repoName] = repository.full_name.split("/");
+
+  const response = await octokit.request('GET /repos/{owner}/{repo}/labels', {
+    owner: templateOwner,
+    repo: templateRepo
+  })
+  try {
+    const {name, description, color} = response.data[0];
+
+    const exists = await octokit.request('GET /repos/{owner}/{repo}/labels/{name}', {
+      owner: repoOwner,
+      repo: repoName,
+      name,
+    }).then(() => true, () => false)
+
+    octokit.log.info(`${name} label exists: ${exists}`)
+    
+    if (!exists) {
+      const label = await octokit.request('POST /repos/{owner}/{repo}/labels', {
+        owner: repoOwner,
+        repo: repoName,
+        name,
+        description,
+        color
+      })
+      octokit.log.info(`${name} updated`)
+    }
+
+  } catch(e) {
+    octokit.log.error(e)
+  }
+
+  // console.log(response)
+}
+
+
+

--- a/script.js
+++ b/script.js
@@ -21,32 +21,34 @@ export async function script(octokit, repository, { template }) {
   const [templateOwner, templateRepo] = template.split("/");
   const [repoOwner, repoName] = repository.full_name.split("/");
 
-  const response = await octokit.request('GET /repos/{owner}/{repo}/labels', {
+  const labels = await octokit.request('GET /repos/{owner}/{repo}/labels', {
     owner: templateOwner,
     repo: templateRepo
   })
   try {
-    const {name, description, color} = response.data[0];
+    for (let i = 0; i < labels.data.length; i++) {
+      const {name, description, color} = labels.data[i];
 
-    const exists = await octokit.request('GET /repos/{owner}/{repo}/labels/{name}', {
-      owner: repoOwner,
-      repo: repoName,
-      name,
-    }).then(() => true, () => false)
-
-    octokit.log.info(`${name} label exists: ${exists}`)
-    
-    if (!exists) {
-      const label = await octokit.request('POST /repos/{owner}/{repo}/labels', {
+      const exists = await octokit.request('GET /repos/{owner}/{repo}/labels/{name}', {
         owner: repoOwner,
         repo: repoName,
         name,
-        description,
-        color
-      })
-      octokit.log.info(`${name} updated`)
-    }
+      }).then(() => true, () => false)
 
+      octokit.log.info(`${name} label exists: ${exists}`)
+      
+      if (!exists) {
+        const label = await octokit.request('POST /repos/{owner}/{repo}/labels', {
+          owner: repoOwner,
+          repo: repoName,
+          name,
+          description,
+          color
+        })
+
+        octokit.log.info(`${name} updated`)
+      }
+    }
   } catch(e) {
     octokit.log.error(e)
   }


### PR DESCRIPTION
# What is this?

- The script now works for all labels on the repo.
- There is a note to use the bypass flag to avoid the confirmation.  

Considerations
- Thanks to gr2m, I got a fast-tracked onboarding on how to use this.
- If the label already exists it will skip the second API call. 