### PR TITLE
Add missing `\` to usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Pass all options as CLI flags to avoid user prompts
 npx octoherd-script-copy-labels \
   --template bdougie/live \
   -T ghp_0123456789abcdefghjklmnopqrstuvwxyzA \
-  -R "bdougie/*"
+  -R "bdougie/*" \
   --octoherd-bypass-confirms true // Optional to bypass each label confirmation.
 ```
 


### PR DESCRIPTION
But I'd suggest to remove the `--octoherd-bypass-confirms` flag from the example. Try running it, the confirmation prompt changed, you can now respond with "don't ask me again" kind of thing. I'd say it's good practise to show the user what the script is changing before doing the change, at least once